### PR TITLE
disable dhcp

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -78,6 +78,7 @@ EOF
     ];
     defaultGateway = "${gateway}";
     defaultGateway6 = "${gateway6}";
+    dhcpcd.enable = false;
     interfaces = {
       $eth0_name = {
         ipv4.addresses = [$(for a in "${eth0_ip4s[@]}"; do echo -n "


### PR DESCRIPTION
DigitalOcean uses static IPs so no point having dhcp daemon running and errors in the log…