### PR TITLE
Fix hardcode of eth0 in several places

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -60,16 +60,20 @@ EOF
           $a"; done)
         ];
 EOF
-    extraRules1="ATTR{address}==\"${ether1}\", NAME=\"eth0\""
+    extraRules1="ATTR{address}==\"${ether1}\", NAME=\"${eth1_name}\""
   else
     interfaces1=""
     extraRules1=""
   fi
 
   nameservers=($(grep ^nameserver /etc/resolv.conf | cut -f2 -d' '))
-
+  if [ "$eth0_name" = eth* ]; then
+    predictable_inames="usePredictableInterfaceNames = lib.mkForce false;"
+  else
+    predictable_inames="usePredictableInterfaceNames = lib.mkForce true;"
+  fi
   cat > /etc/nixos/networking.nix << EOF
-{ ... }: {
+{ lib, ... }: {
   # This file was populated at runtime with the networking
   # details gathered from the active system.
   networking = {
@@ -79,6 +83,7 @@ EOF
     defaultGateway = "${gateway}";
     defaultGateway6 = "${gateway6}";
     dhcpcd.enable = false;
+    $predictable_inames
     interfaces = {
       $eth0_name = {
         ipv4.addresses = [$(for a in "${eth0_ip4s[@]}"; do echo -n "
@@ -92,7 +97,7 @@ EOF
     };
   };
   services.udev.extraRules = ''
-    ATTR{address}=="${ether0}", NAME="eth0"
+    ATTR{address}=="${ether0}", NAME="${eth0_name}"
     $extraRules1
   '';
 }


### PR DESCRIPTION
The problem was that some VPS (from GigaCloud provider, Ukraine) provided `ens3` interface
name, but after infection it was renamed to `eth0` via udev rules.

This fixes hardcode in two ways: 
- actually fix hardcode
- specify `networking.usePredictableInterfaceNames` explicitly

I thinkg, both approaches can replace each other (and work in combo too). So, we can leave udev rules and drop usePredictableInterfaceNames, leave usePredictableInterfaceNames and drop udev rules, or leave both. I've chose the last variant here, because I can't test this on Digital Ocean.

Also, this partially overlaps with https://github.com/elitak/nixos-infect/pull/17 (and maybe closes it).