### PR TITLE
more robust removeSwap

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -122,11 +122,8 @@ makeSwap() {
 }
 
 removeSwap() {
-    for swapFile in /tmp/nixos-infect.*.swp
-    do
-        swapoff -v "$swapFile"
-        rm -vf "$swapFile"
-    done
+    swapoff -a
+    rm -vf /tmp/nixos-infect.*.swp
 }
 
 prepareEnv() {


### PR DESCRIPTION
During my nixos-infect tests I have sometimes canceled infection in the middle.
Rerun of nixos-infect failed because there were some old swap files, which
were no longer available as swap devices.

`swapoff -a` will handle this for us (we are going reboot anyway)