### PR TITLE
add NO_REBOOT variable

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -258,4 +258,4 @@ makeConf
 makeSwap # smallest (512MB) droplet needs extra memory!
 infect
 removeSwap
-reboot
+[[ -z "$NO_REBOOT" ]] && reboot


### PR DESCRIPTION
Useful when nixos-infect is used within programs that manage the
machine's state, like nixops.

See e.g. [this](https://github.com/NixOS/nixops/blob/264fc018041fa0e856a55fa3f63a62a7d3e6e4fc/nixops/backends/digital_ocean.py#L189-L195) for a case in which the machine's state is handled outside nixos-infect.