### PR TITLE
Making swap sooner as dnf under DigitalOcean requires more memory

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -253,9 +253,9 @@ infect() {
 [ -z "$PROVIDER" ] && PROVIDER="digitalocean" # you may also prepend PROVIDER=vultr to your call instead
 
 prepareEnv
+makeSwap # smallest (512MB) droplet needs extra memory!
 checkEnv
 makeConf
-makeSwap # smallest (512MB) droplet needs extra memory!
 infect
 removeSwap
 


### PR DESCRIPTION
Running nixos-infect on DigitalOcean on smallest droplets with Fedora 30 results in dnf crash during the CheckEnv phase. 

`(remote-exec):   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current`
`(remote-exec):                                  Dload  Upload   Total   Spent    Left  Speed`
`(remote-exec):   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0`
`(remote-exec): 100  8626  100  8626    0     0  45882      0 --:--:-- --:--:-- --:--:-- 45882`
`(remote-exec): /usr/bin/curl`
`(remote-exec): /usr/bin/dnf`
`(remote-exec): Fedora Modular 30 - x86_64                      3.0 MB/s | 2.1 MB     00:00`
`(remote-exec): Fedora Modular 30 - x86_64 - Updates            4.3 MB/s | 2.9 MB     00:00`
`(remote-exec): Fedora 30 - x86_64 - Updates                     17 MB/s | 8.6 MB     00:00`
`(remote-exec): Fedora 30 - x86_64                               17 MB/s |  54 MB     00:03`
`(remote-exec): main: line 190:   812 Killed                  dnf install -y perl-Digest-SHA`

This changes makes sure to setup swap before running dnf (which will pull metadata).