### PR TITLE
Make routes config explicit.

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -105,6 +105,8 @@ EOF
         ipv6.addresses = [$(for a in "${eth0_ip6s[@]}"; do echo -n "
           $a"; done)
         ];
+        ipv4.routes = [ { address = "${gateway}"; prefixLength = 32; } ];
+        ipv6.routes = [ { address = "${gateway6}"; prefixLength = 32; } ];
       };
       $interfaces1
     };


### PR DESCRIPTION
This helps Hetzner Cloud, which doesn't populate routes by
default and thus network doesn't work.

Fixes https://github.com/elitak/nixos-infect/issues/25

Didn't test DigitalOcean, Vultr and other providers.