### PR TITLE
RFE: Root password

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -4,11 +4,17 @@
 
 set -e -o pipefail
 
+ROOT_PASSWORD=
+
 makeConf() {
   # Skip everything if main config already present
   [[ -e /etc/nixos/configuration.nix ]] && return 0
   # NB <<"EOF" quotes / $ ` in heredocs, <<EOF does not
   mkdir -p /etc/nixos
+  # generate some default password, to make login possible if network is down
+  set +o pipefail
+  ROOT_PASSWORD="$(cat /dev/urandom | tr -dc _A-Z-a-z-0-9 | head -c12)"
+  set -o pipefail
   # Prevent grep for sending error code 1 (and halting execution) when no lines are selected : https://www.unix.com/man-page/posix/1P/grep
   local IFS=$'\n'; keys=($(grep -vE '^[[:space:]]*(#|$)' /root/.ssh/authorized_keys || [[ $? == 1 ]])) 
   local network_import=""
@@ -29,6 +35,9 @@ makeConf() {
   users.users.root.openssh.authorizedKeys.keys = [$(for key in "${keys[@]}"; do echo -n "
     \"$key\""; done)
   ];
+  $([ -n "$ROOT_PASSWORD" ] && echo "
+    users.users.root.password = ''$ROOT_PASSWORD'';
+  ")
 }
 EOF
   # If you rerun this later, be sure to prune the filesSystems attr
@@ -261,6 +270,14 @@ checkEnv
 makeConf
 infect
 removeSwap
+
+
+if [ -n "$ROOT_PASSWORD" ]; then
+  echo "-----"
+  echo "Root password set: $ROOT_PASSWORD"
+  echo "You can use it if instance is not reachable through SSH. Don't forget to change it after infection complete."
+  echo "-----"
+fi
 
 if [[ -z "$NO_REBOOT" ]]; then
   reboot

--- a/nixos-infect
+++ b/nixos-infect
@@ -105,6 +105,8 @@ EOF
         ipv6.addresses = [$(for a in "${eth0_ip6s[@]}"; do echo -n "
           $a"; done)
         ];
+        ipv4.routes = [ { address = "${gateway}"; prefixLength = 32; } ];
+        ipv6.routes = [ { address = "${gateway6}"; prefixLength = 32; } ];
       };
       $interfaces1
     };


### PR DESCRIPTION
generate random password for root as initial configuration

Some cloud providers allow web console login (Hetzner Cloud, for example).
You can then login and fix network issues (if any).

This change generates a password for root, so it is 1 step easier to do.

(this includes https://github.com/elitak/nixos-infect/pull/39)