### PR TITLE
Improve compatibility with authorized_keys file format

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -10,7 +10,12 @@ makeConf() {
   # NB <<"EOF" quotes / $ ` in heredocs, <<EOF does not
   mkdir -p /etc/nixos
   # Prevent grep for sending error code 1 (and halting execution) when no lines are selected : https://www.unix.com/man-page/posix/1P/grep
-  local IFS=$'\n'; keys=($(grep -vE '^[[:space:]]*(#|$)' /root/.ssh/authorized_keys || [[ $? == 1 ]])) 
+  local IFS=$'\n' 
+  for trypath in /root/.ssh/authorized_keys $HOME/.ssh/authorized_keys; do 
+      [[ -r "$trypath" ]] \
+      && keys=$(sed -E 's/^.*((ssh|ecdsa)-[^[:space:]]+)[[:space:]]+([^[:space:]]+)([[:space:]]*.*)$/\1 \3\4/' "$trypath") \
+      && break
+  done
   local network_import=""
 
   [ "$PROVIDER" = "digitalocean" ] && network_import="./networking.nix # generated at runtime by nixos-infect"
@@ -26,8 +31,8 @@ makeConf() {
   networking.hostName = "$(hostname)";
   networking.firewall.allowPing = true;
   services.openssh.enable = true;
-  users.users.root.openssh.authorizedKeys.keys = [$(for key in "${keys[@]}"; do echo -n "
-    \"$key\""; done)
+  users.users.root.openssh.authorizedKeys.keys = [$(while read -r line; do echo -n "
+    \"$line\" "; done <<< "$keys")
   ];
 }
 EOF


### PR DESCRIPTION
closes #43 
With this change the parsing of the authorized_keys file should become fully compatible to all variations allowed by this definition:
```
AUTHORIZED_KEYS FILE FORMAT
     AuthorizedKeysFile specifies the files containing public keys for public
     key authentication; if this option is not specified, the default is
     ~/.ssh/authorized_keys and ~/.ssh/authorized_keys2.  Each line of the file
     contains one key (empty lines and lines starting with a ‘#’ are ignored as
     comments).  Public keys consist of the following space-separated fields:
     options, keytype, base64-encoded key, comment.  The options field is
     optional.  The keytype is “ecdsa-sha2-nistp256”, “ecdsa-sha2-nistp384”,
     “ecdsa-sha2-nistp521”, “ssh-ed25519”, “ssh-dss” or “ssh-rsa”; the comment
     field is not used for anything (but may be convenient for the user to
     identify the key).
```