### PR TITLE
Add -L option to curl to follow 301 redirect

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -232,7 +232,7 @@ infect() {
   #addgroup nixbld -g 30000 || true
   #for i in {1..10}; do adduser -DH -G nixbld nixbld$i || true; done
 
-  curl https://nixos.org/nix/install | $SHELL
+  curl -L https://nixos.org/nix/install | $SHELL
 
   # shellcheck disable=SC1090
   source ~/.nix-profile/etc/profile.d/nix.sh


### PR DESCRIPTION
https://nixos.org/nix/install is in fact a redirect that returns `301` to `https://releases.nixos.org/nix/nix-X.X.X/install`. `curl` does not follow redirects by default, but it does with `-L` option.

No changes needed to `fakeCurlUsingWget()` because `wget` does follow `301` redirects by default.