### PR TITLE
Prefer to if to '&&'

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -46,7 +46,12 @@ EOF
 }
 EOF
 
-  [[ -n "$doNetConf" ]] && makeNetworkingConf
+  if [[ -n "$doNetConf" ]]
+  then
+    makeNetworkingConf
+  else
+    true
+  fi
 }
 
 makeNetworkingConf() {

--- a/nixos-infect
+++ b/nixos-infect
@@ -46,12 +46,7 @@ EOF
 }
 EOF
 
-  if [[ -n "$doNetConf" ]]
-  then
-    makeNetworkingConf
-  else
-    true
-  fi
+  [[ -n "$doNetConf" ]] && makeNetworkingConf || true
 }
 
 makeNetworkingConf() {


### PR DESCRIPTION
The '&&' causes this script to fail if $dotNetConf is not set due to 'set -e'