### PR TITLE
avoid using NIX_PATH in resulting hardware-configuration.nix

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -38,9 +38,9 @@ makeConf() {
 EOF
   # If you rerun this later, be sure to prune the filesSystems attr
   cat > /etc/nixos/hardware-configuration.nix << EOF
-{ ... }:
+{ modulesPath, ... }:
 {
-  imports = [ <nixpkgs/nixos/modules/profiles/qemu-guest.nix> ];
+  imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
   boot.loader.grub.device = "$grubdev";
   fileSystems."/" = { device = "$rootfsdev"; fsType = "ext4"; };
 }


### PR DESCRIPTION
This makes the resulting `hardware-configuration.nix` usable from a system that is a nix flake without having to replace that usage of `NIX_PATH` first.

**Longer explanation for this change:**
I had used nixos-infect to install NixOS on a DigitalOcean Droplet.
I then had to make a change like this manually and directly to the `hardware-configuration.nix`file so that I could turn that system into a flake-based system that re-uses the same `hardware-configuration.nix`file, because flake-based systems cannot depend on `NIX_PATH`. In my opinion this is a tedious manual step and it would be nice if people did not have to do this.

My proposal to fix that is this PR. I modified nixos-infect to directly produce that updated `hardware-configuration.nix` file and tested that the install still works like that by installing 20.03 on a Digital Ocean Droplet.