### PR TITLE
Fix prefixLength for route of IPv6 gateway

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -108,7 +108,7 @@ EOF
           $a"; done)
         ];
         ipv4.routes = [ { address = "${gateway}"; prefixLength = 32; } ];
-        ipv6.routes = [ { address = "${gateway6}"; prefixLength = 32; } ];
+        ipv6.routes = [ { address = "${gateway6}"; prefixLength = 128; } ];
       };
       $interfaces1
     };


### PR DESCRIPTION
While looking at my configuration, I noticed that `prefixLength` was incorrectly set to 32. While I haven't tested it, I think this misconfiguration makes every host within this very broad subnetwork (but outside your local network) unreachable.