### PR TITLE
Add basic NVMe support

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -137,7 +137,7 @@ removeSwap() {
 
 prepareEnv() {
   # $grubdev is used in makeConf()
-  for grubdev in /dev/vda /dev/sda; do [[ -e $grubdev ]] && break; done
+  for grubdev in /dev/vda /dev/sda /dev/nvme0n1 ; do [[ -e $grubdev ]] && break; done
 
   # Retrieve root fs block device
   #                   (get root mount)  (get partition or logical volume)

--- a/nixos-infect
+++ b/nixos-infect
@@ -42,6 +42,7 @@ EOF
 {
   imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
   boot.loader.grub.device = "$grubdev";
+  boot.initrd.kernelModules = [ "nvme" ];
   fileSystems."/" = { device = "$rootfsdev"; fsType = "ext4"; };
 }
 EOF


### PR DESCRIPTION
This allows lucky people on NVMe machines to `nixos-infect` successfully. Firstly by considering an NVMe device as a booting possibility, then ensuring the kernel module is present in the initrd to allow booting from it as a root device.

On a side note, I do have a complete branch @ https://github.com/risicle/nixos-infect/tree/ris-phoenixnap-bmc adding support for phoenixnap's "bare metal cloud" product, but it involves a significant addition - using a `jq` script to convert a netplan yaml config into a nixos `networking` configuration, and I don't know how you'd feel about incorporating this. Perhaps it would be better to keep it as a fork? Up to you really.