### PR TITLE
Add a search path /home/$SUDO_USER/ for ssh keys

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -11,7 +11,7 @@ makeConf() {
   mkdir -p /etc/nixos
   # Prevent grep for sending error code 1 (and halting execution) when no lines are selected : https://www.unix.com/man-page/posix/1P/grep
   local IFS=$'\n'
-  for trypath in /root/.ssh/authorized_keys $HOME/.ssh/authorized_keys; do
+  for trypath in /root/.ssh/authorized_keys /home/$SUDO_USER/.ssh/authorized_keys $HOME/.ssh/authorized_keys; do
       [[ -r "$trypath" ]] \
       && keys=$(sed -E 's/^.*((ssh|ecdsa)-[^[:space:]]+)[[:space:]]+([^[:space:]]+)([[:space:]]*.*)$/\1 \3\4/' "$trypath") \
       && break


### PR DESCRIPTION
Limited utility for most people but if there are (dumb) people like me whose first run of scripts precedes the first read of the manual and are users of sudo, this might be a tiny bit helpful. This (should) work(s) under two scenarios: `sudo nixos-infect` and `sudo su` followed by `./nixos-infect`. 

E.g.

```
ubuntu@nixos:~$ cat blah.sh
#!/bin/bash
whoami
echo $SUDO_USER
echo $HOME

ubuntu@nixos:~$ sudo ./blah.sh
root
ubuntu
/root

ubuntu@nixos:~$ sudo su
root@nixos:/home/ubuntu# ./blah.sh
root
ubuntu
/root

```


Thank you for creating this, it's such a life saver.