### PR TITLE
Enable `zramSwap.enable` by default

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -28,6 +28,7 @@ makeConf() {
   ];
 
   boot.cleanTmpDir = true;
+  zramSwap.enable = true;
   networking.hostName = "$(hostname)";
   services.openssh.enable = true;
   users.users.root.openssh.authorizedKeys.keys = [$(while read -r line; do echo -n "


### PR DESCRIPTION
`nixos-rebuild` may consume more than 1GB memory even on a freshly-installed NixOS machine. This causes some "budget" machine with insufficient (e.g. less than 1GB) memory suffer from frequent interruption due to nix being killed by LMK. nixos-infect does enable extra swap during installation, but this is not the case with the new system.

Enabling zram (via `zramSwap.enable`) would make it less painful for those machines. Also it is recommended for most machines since the advantages surpass the disadvantages.