### PR TITLE
Also check for /dev/xvda (Xen)

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -176,7 +176,7 @@ prepareEnv() {
   if isEFI; then
     esp="$(findESP)"
   else
-    for grubdev in /dev/vda /dev/sda /dev/nvme0n1 ; do [[ -e $grubdev ]] && break; done
+    for grubdev in /dev/vda /dev/sda /dev/xvda /dev/nvme0n1 ; do [[ -e $grubdev ]] && break; done
   fi
 
   # Retrieve root fs block device


### PR DESCRIPTION
It was a tentative to make it work on Amazon Lightsail, but this is not enough. After reboot, the host does not come back. As Lightsail does not provide a console, I just gave up.