### PR TITLE
infect: have swap usage optional

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -310,10 +310,14 @@ infect() {
 
 checkEnv
 prepareEnv
-makeSwap # smallest (512MB) droplet needs extra memory!
+if [[ -z "$NO_SWAP" ]]; then
+    makeSwap # smallest (512MB) droplet needs extra memory!
+fi
 makeConf
 infect
-removeSwap
+if [[ -z "$NO_SWAP" ]]; then
+    removeSwap
+fi
 
 if [[ -z "$NO_REBOOT" ]]; then
   reboot


### PR DESCRIPTION
Doesn't work everywhere with swapon, e.g. osuosl openstack cluster.

Without swap it can succeed though, it's not a hard prerequisite for the
infection to take effect.