### PR TITLE
Using sh instead of $SHELL

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -264,7 +264,7 @@ infect() {
   #addgroup nixbld -g 30000 || true
   #for i in {1..10}; do adduser -DH -G nixbld nixbld$i || true; done
 
-  curl -L https://nixos.org/nix/install | $SHELL
+  curl -L https://nixos.org/nix/install | sh
 
   # shellcheck disable=SC1090
   source ~/.nix-profile/etc/profile.d/nix.sh


### PR DESCRIPTION
Nix install script should be parsed by a Bourne-like shell, like bash
or sh. If the user invokes the script using a Korn shell or a Z Shell,
the script won't work. Nix documentation says to use "sh".