### PR TITLE
Improve flexibility, enable pre-setting NIXOS_CONFIG, & NIXOS_LUSTRATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,12 @@ Before executing the install script, you may need to check your mounts with `df 
 ### Oracle Cloud Infrastructure
 Tested for both VM.Standard.E2.1.Micro (x86) and VM.Standard.A1.Flex (AArch64) instances.
 #### Tested on
-|Distribution|       Name      | Status    | test date|
-|------------|-----------------|-----------|----------|
-|Oracle Linux| 7.9             |**success**|2021-05-31|
-|Ubuntu      | 20.04           |**success**|2022-03-23|
+|Distribution|       Name      | Status    | test date|   Shape  |
+|------------|-----------------|-----------|----------|----------|
+|Oracle Linux| 7.9             |**success**|2021-05-31|          |
+|Ubuntu      | 20.04           |**success**|2022-03-23|          |
+|Ubuntu      | 20.04           |**success**|2022-04-19| free arm |
+|Oracle Linux| 8.0             |**failed** |2022-04-19| free amd |
 
 ### Aliyun ECS
 

--- a/README.md
+++ b/README.md
@@ -187,8 +187,13 @@ Tested for both VM.Standard.E2.1.Micro (x86) and VM.Standard.A1.Flex (AArch64) i
 |Oracle Linux| 7.9             |**success**|2021-05-31|          |
 |Ubuntu      | 20.04           |**success**|2022-03-23|          |
 |Ubuntu      | 20.04           |**success**|2022-04-19| free arm |
-|Oracle Linux| 8.0             |**failed** |2022-04-19| free amd |
+|Oracle Linux| 8.0             | -failure- |2022-04-19| free amd |
+|CentOS      | 8.0             | -failure- |2022-04-19| free amd |
+|Oracle Linux| 7.9[1]          |**success**|2022-04-19| free amd |
 
+    [1] The Oracle 7.9 layout has 200Mb for /boot 8G for swap
+    PR#100 Adopted 8G Swap device
+    
 ### Aliyun ECS
 
 Aliyun ECS tested on ecs.s6-c1m2.large, region **cn-shanghai**, needs a little bit tweaks:

--- a/nixos-infect
+++ b/nixos-infect
@@ -147,7 +147,7 @@ checkExistingSwap() {
   swapcfg=""
   if [[ -n "$SWAPSHOW" ]]; then
     SWAP_DEVICE="${SWAPSHOW%% *}"
-    if [[ "$SWAP_DEVICE" == dev* ]]; then
+    if [[ "$SWAP_DEVICE" == /dev/* ]]; then
       zramswap=false
       swapcfg="swapDevices = [ { device = \"${SWAP_DEVICE}\"; } ];"
       NO_SWAP=true 

--- a/nixos-infect
+++ b/nixos-infect
@@ -274,7 +274,7 @@ infect() {
   nix-channel --add "https://nixos.org/channels/$NIX_CHANNEL" nixos
   nix-channel --update
 
-  export NIXOS_CONFIG=/etc/nixos/configuration.nix
+  export NIXOS_CONFIG="${NIXOS_CONFIG:-/etc/nixos/configuration.nix}"
 
   nix-env --set \
     -I nixpkgs=$HOME/.nix-defexpr/channels/nixos \
@@ -291,7 +291,7 @@ infect() {
 
   # Stage the Nix coup d'état
   touch /etc/NIXOS
-  echo etc/nixos                   > /etc/NIXOS_LUSTRATE
+  echo etc/nixos                  >> /etc/NIXOS_LUSTRATE
   echo etc/resolv.conf            >> /etc/NIXOS_LUSTRATE
   echo root/.nix-defexpr/channels >> /etc/NIXOS_LUSTRATE
 

--- a/nixos-infect
+++ b/nixos-infect
@@ -28,7 +28,7 @@ makeConf() {
   ];
 
   boot.cleanTmpDir = true;
-  zramSwap.enable = true;
+  zramSwap.enable = ${zramswap};
   networking.hostName = "$(hostname)";
   services.openssh.enable = true;
   users.users.root.openssh.authorizedKeys.keys = [$(while read -r line; do echo -n "
@@ -62,6 +62,7 @@ EOF
 $bootcfg
   boot.initrd.kernelModules = [ "nvme" ];
   fileSystems."/" = { device = "$rootfsdev"; fsType = "$rootfstype"; };
+  $swapcfg
 }
 EOF
 
@@ -140,8 +141,18 @@ EOF
 EOF
 }
 
+chkSwap() {
+  SWAPSHOW=$(swapon --show --noheadings --raw)
+  zramswap=true
+  swapcfg=""
+  if [[ -n "$SWAPSHOW" ]]; then
+    zramswap=false
+    swapcfg="swapDevices = [ { device = "${SWAPSHOW%% *}"; } ];"
+    NO_SWAP=true 
+  fi
+}
+
 makeSwap() {
-  # TODO check currently available swapspace first
   swapFile=$(mktemp /tmp/nixos-infect.XXXXX.swp)
   dd if=/dev/zero "of=$swapFile" bs=1M count=$((1*1024))
   chmod 0600 "$swapFile"
@@ -297,9 +308,10 @@ infect() {
 
   rm -rf /boot.bak
   isEFI && umount "$esp"
-  mv -v /boot /boot.bak
+
+  mv -v /boot /boot.bak || { cp -a /boot /book.bak ; rm -rf /boot/* ; umount /boot ; }
   if isEFI; then
-    mkdir /boot
+    mkdir -p /boot
     mount "$esp" /boot
     find /boot -depth ! -path /boot -exec rm -rf {} +
   fi
@@ -310,6 +322,7 @@ infect() {
 
 checkEnv
 prepareEnv
+chkSwap
 if [[ -z "$NO_SWAP" ]]; then
     makeSwap # smallest (512MB) droplet needs extra memory!
 fi

--- a/nixos-infect
+++ b/nixos-infect
@@ -147,7 +147,7 @@ checkExistingSwap() {
   swapcfg=""
   if [[ -n "$SWAPSHOW" ]]; then
     SWAP_DEVICE="${SWAPSHOW%% *}"
-    if [[ "$SWAP_DEVICE" == /dev/* ]]; then
+    if [[ "$SWAP_DEVICE" == "/dev/"* ]]; then
       zramswap=false
       swapcfg="swapDevices = [ { device = \"${SWAP_DEVICE}\"; } ];"
       NO_SWAP=true 

--- a/nixos-infect
+++ b/nixos-infect
@@ -141,14 +141,17 @@ EOF
 EOF
 }
 
-chkSwap() {
+checkExistingSwap() {
   SWAPSHOW=$(swapon --show --noheadings --raw)
   zramswap=true
   swapcfg=""
   if [[ -n "$SWAPSHOW" ]]; then
-    zramswap=false
-    swapcfg="swapDevices = [ { device = \"${SWAPSHOW%% *}\"; } ];"
-    NO_SWAP=true 
+    SWAP_DEVICE="${SWAPSHOW%% *}"
+    if [[ "$SWAP_DEVICE" == dev* ]]; then
+      zramswap=false
+      swapcfg="swapDevices = [ { device = \"${SWAP_DEVICE}\"; } ];"
+      NO_SWAP=true 
+    fi
   fi
 }
 
@@ -322,7 +325,7 @@ infect() {
 
 checkEnv
 prepareEnv
-chkSwap
+checkExistingSwap
 if [[ -z "$NO_SWAP" ]]; then
     makeSwap # smallest (512MB) droplet needs extra memory!
 fi

--- a/nixos-infect
+++ b/nixos-infect
@@ -147,7 +147,7 @@ chkSwap() {
   swapcfg=""
   if [[ -n "$SWAPSHOW" ]]; then
     zramswap=false
-    swapcfg="swapDevices = [ { device = "${SWAPSHOW%% *}"; } ];"
+    swapcfg="swapDevices = [ { device = \"${SWAPSHOW%% *}\"; } ];"
     NO_SWAP=true 
   fi
 }


### PR DESCRIPTION
This allows the user to checkout their own git repo and add that to NIXOS_LUSTRATE prior to infection.

From there, either NIXOS_IMPORT is supplied to invoke users own configuration, or NIXOS_CONFIG can now be overriden.