### PR TITLE
Added cockbox support and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This script has successfully been tested on at least the follow hosting provider
 * [OVHcloud](https://www.ovh.com/)
 * [Oracle Cloud Infrastructure](https://www.oracle.com/cloud/)
 * [GalaxyGate](https://galaxygate.net)
+* [Cockbox](https://cockbox.org)
 
 Should you find that it works on your hoster,
 feel free to update this README and issue a pull request.
@@ -211,3 +212,11 @@ Aliyun ECS tested on ecs.s6-c1m2.large, region **cn-shanghai**, needs a little b
 |Distribution|       Name      | Status    | test date|
 |------------|-----------------|-----------|----------|
 |Ubuntu      | 20.04           |**success**|2022-04-02|
+
+
+### Cockbox
+Requred some Xen modules to work out, after that NixOS erected itself without a hinch.
+#### Tested on
+|Distribution|       Name      | Status    | test date|
+|------------|-----------------|-----------|----------|
+|Ubuntu      | 20.04           |**success**|2022-06-12|

--- a/nixos-infect
+++ b/nixos-infect
@@ -60,6 +60,7 @@ EOF
 {
   imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
 $bootcfg
+  boot.initrd.availableKernelModules = [ "ata_piix" "uhci_hcd" "xen_blkfront" ];
   boot.initrd.kernelModules = [ "nvme" ];
   fileSystems."/" = { device = "$rootfsdev"; fsType = "$rootfstype"; };
   $swapcfg


### PR DESCRIPTION
This required adding some modules to available kernel modules. Maybe we want to run `nixos-generate-config` to get required ones in the script in the future?