### PR TITLE
Only include vmw_pvscsi on x64_64

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -54,13 +54,18 @@ EOF
 )
   fi
 
+  availableKernelModules=('"ata_piix"' '"uhci_hcd"' '"xen_blkfront"')
+  if isX86_64; then
+    availableKernelModules+=('"vmw_pvscsi"')
+  fi
+
   # If you rerun this later, be sure to prune the filesSystems attr
   cat > /etc/nixos/hardware-configuration.nix << EOF
 { modulesPath, ... }:
 {
   imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
 $bootcfg
-  boot.initrd.availableKernelModules = [ "ata_piix" "uhci_hcd" "vmw_pvscsi" "xen_blkfront" ];
+  boot.initrd.availableKernelModules = [ ${availableKernelModules[@]} ];
   boot.initrd.kernelModules = [ "nvme" ];
   fileSystems."/" = { device = "$rootfsdev"; fsType = "$rootfstype"; };
   $swapcfg
@@ -167,6 +172,10 @@ makeSwap() {
 removeSwap() {
   swapoff -a
   rm -vf /tmp/nixos-infect.*.swp
+}
+
+isX86_64 {
+  [[ "$(uname -m)" == "x86_64" ]]
 }
 
 isEFI() {


### PR DESCRIPTION
Fix https://github.com/elitak/nixos-infect/issues/117 (caused by https://github.com/elitak/nixos-infect/pull/115) by not including vmw_pvscsi in boot.initrd.availableKernelModules no aarch64.

I have been able to install nixos successfully on AMD and Ampere instances on Oracle Cloud using this.