### PR TITLE
Fix ssh host key permissions on Oracle Linux

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -275,6 +275,10 @@ checkEnv() {
   req ip               || { echo "ERROR: Missing ip";                  return 1; }
   req awk              || { echo "ERROR: Missing awk";                 return 1; }
   req cut || req df    || { echo "ERROR: Missing coreutils (cut, df)"; return 1; }
+
+  # On some versions of Oracle Linux these have the wrong permissions,
+  # which stops sshd from starting when NixOS boots
+  chmod 600 /etc/ssh/ssh_host_*_key
 }
 
 infect() {


### PR DESCRIPTION
When running nixos-infect on Oracle Linux 8 (on Oracle Cloud, with both AMD and ARM), I found that sshd refused to start when NixOS booted, because the private ssh host keys were 640 instead of 600 (i.e. `-rw-r-----` instead of `-rw-------`.

With this patch, I was able to run nixos-infect on Oracle Linux, and connect via ssh after rebooting.
