### PR TITLE
Fix installation with FQDNs

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -29,7 +29,8 @@ makeConf() {
 
   boot.cleanTmpDir = true;
   zramSwap.enable = ${zramswap};
-  networking.hostName = "$(hostname)";
+  networking.hostName = "$(hostname -s)";
+  networking.domain = "$(hostname -d)";
   services.openssh.enable = true;
   users.users.root.openssh.authorizedKeys.keys = [$(while read -r line; do echo -n "
     \"$line\" "; done <<< "$keys")


### PR DESCRIPTION
This seems to be caused by the install script putting the entire hostname in `networking.hostName` when it should separate out the domain name into `networking.domain`.

Note that these changes will set `networking.domain` to `""` if the domain is empty. This is okay, NixOS appears to accept it in my tests.

## Reproducing the error

<details>

I started with a fresh VM on Contabo but it likely isn't a contabo-only issue. Contabo appends a domain name to the end of their fresh servers.

```
root@vmi1086306:~# apt show hostname
Package: hostname
Version: 3.23
Priority: required
Essential: yes
Section: admin
Maintainer: Michael Meskes <meskes@debian.org>
Installed-Size: 51.2 kB
Pre-Depends: libc6 (>= 2.4)
Breaks: nis (<< 3.17-30)
Replaces: nis (<< 3.17-30)
Tag: implemented-in::c, interface::commandline, role::program,
 scope::utility, use::configuring
Download-Size: 14.9 kB
APT-Manual-Installed: yes
APT-Sources: http://asi-fs-w.contabo.net/debian bullseye/main amd64 Packages
Description: utility to set/show the host name or domain name
 This package provides commands which can be used to display the system's
 DNS name, and to display or set its hostname or NIS domain name.

root@vmi1086306:~# hostname
vmi1086306.contaboserver.net
root@vmi1086306:~# hostname -s
vmi1086306
root@vmi1086306:~# hostname -d
contaboserver.net
root@vmi1086306:~# cat /etc/hostname
vmi1086306.contaboserver.net
root@vmi1086306:~# cat /etc/hosts
127.0.0.1	localhost

# The following lines are desirable for IPv6 capable hosts
::1     localhost ip6-localhost ip6-loopback
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
154.53.59.80 vmi1086306.contaboserver.net vmi1086306
```

Running the install, here's the result:

```
root@vmi1086306:~# curl https://raw.githubusercontent.com/elitak/nixos-infect/master/nixos-infect | NIX_CHANNEL=nixos-22.05 bash -x

<snip, everything before this worked>

+ nix-channel --add https://nixos.org/channels/nixos-22.05 nixos
+ nix-channel --update
unpacking channels...
+ export NIXOS_CONFIG=/etc/nixos/configuration.nix
+ NIXOS_CONFIG=/etc/nixos/configuration.nix
+ nix-env --set -I nixpkgs=/root/.nix-defexpr/channels/nixos -f '<nixpkgs/nixos>' -p /nix/var/nix/profiles/system -A system
error: A definition for option `networking.hostName' is not of type `string matching the pattern ^$|^[[:alnum:]]([[:alnum:]_-]{0,61}[[:alnum:]])?$'. Definition values:
       - In `/etc/nixos/configuration.nix': "vmi1086306.contaboserver.net"
(use '--show-trace' to show detailed location information)
root@vmi1086306:~#
```

Here's the contents of `/etc/nixos/configuration.nix`:

```nix
{ ... }: {
  imports = [
    ./hardware-configuration.nix


  ];

  boot.cleanTmpDir = true;
  zramSwap.enable = true;
  networking.hostName = "vmi1086306.contaboserver.net";
  services.openssh.enable = true;
  users.users.root.openssh.authorizedKeys.keys = [
    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEl4yuE1X4IqjBqt/enMyZFZKJQLxeq34BTCNqey59aZ astrid@chungus"
  ];
}
```

It *should* look like this instead:
```nix
{
  networking.hostName = "vmi1086306";
  networking.domain = "contaboserver.net";
}
```

</details>

## Temporary workaround

Manually separating out the hostName and domain in `/etc/nixos/configuration.nix`, then running the script again, works.

## Testing that this patch works

The following command (ran as root) should test my patched version:
```
curl https://raw.githubusercontent.com/ifd3f/nixos-infect/fqdn-fix/nixos-infect | NIX_CHANNEL=nixos-22.05 bash -x
```

I have tested it to work on:
- [x] the original machine it failed on, with a fully-qualified domain name
- [x] a different machine with a domain that wasn't fully-qualified