### PR TITLE
Add Windcloud as provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This script has successfully been tested on at least the follow hosting provider
 * [Cockbox](https://cockbox.org)
 * [Google Cloud Platform](https://cloud.google.com/)
 * [Contabo](https://contabo.com)
+* [Windcloud](https://windcloud.de/)
 
 Should you find that it works on your hoster,
 feel free to update this README and issue a pull request.
@@ -241,3 +242,10 @@ Tested on Cloud VPS. Contabo sets the hostname to something like `vmi######.cont
 |Distribution|       Name      | Status    | test date|
 |------------|-----------------|-----------|----------|
 |Ubuntu      | 22.04           |**success**|2022-09-26|
+
+### Windcloud
+Tested on vServer. The network configuration seems to be important so the same tweaks as for DigitalOcean are necessary (see above).
+#### Tested on
+|Distribution|       Name      | Status    | test date|
+|------------|-----------------|-----------|----------|
+|Ubuntu      | 20.04           |**success**|2022-12-09|


### PR DESCRIPTION
Hi,

thanks a lot for your script, this is good stuff! I tried it with German provider Windcloud and documented my findings.
I got it working the the auto-generated networking.nix (as needed by DigitalOcean).

I guess a clean approach would be to add `windcloud` as a provider in the shell script; something like

```bash
[ "$PROVIDER" = "windcloud" ] && doNetConf=y # windcloud requires detailed network config to be generated  
```
(Or change the DO-if-statement). I'm happy to introduce something here but I did not want to do this until feedback from you.