### PR TITLE
fix: generate network config for Hetzner Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ When creating a server provide the following script as "User data":
 ```
 #!/bin/sh
 
-curl https://raw.githubusercontent.com/elitak/nixos-infect/master/nixos-infect | NIX_CHANNEL=nixos-22.05 bash 2>&1 | tee /tmp/infect.log
+curl https://raw.githubusercontent.com/elitak/nixos-infect/master/nixos-infect | PROVIDER=hetznercloud NIX_CHANNEL=nixos-22.05 bash 2>&1 | tee /tmp/infect.log
 ```
 
 #### Tested on

--- a/nixos-infect
+++ b/nixos-infect
@@ -140,7 +140,10 @@ EOF
   networking = {
     nameservers = [ ${nameservers[@]} ];
     defaultGateway = "${gateway}";
-    defaultGateway6 = "${gateway6}";
+    defaultGateway6 = {
+      address = "${gateway6}";
+      interface = "${eth0_name}";
+    };
     dhcpcd.enable = false;
     $predictable_inames
     interfaces = {
@@ -362,7 +365,7 @@ infect() {
 
 [ "$PROVIDER" = "digitalocean" ] && doNetConf=y # digitalocean requires detailed network config to be generated
 [ "$PROVIDER" = "lightsail" ] && newrootfslabel="nixos"
-if [[ "$PROVIDER" = "digitalocean" ]] || [[ "$PROVIDER" = "servarica" ]]; then
+if [[ "$PROVIDER" = "digitalocean" ]] || [[ "$PROVIDER" = "servarica" ]] || [[ "$PROVIDER" = "hetznercloud" ]]; then
 	doNetConf=y # some providers require detailed network config to be generated
 fi
 


### PR DESCRIPTION
Fixes #106 

Implemented solution mentioned by @bramd in [the answer](https://github.com/elitak/nixos-infect/issues/106#issuecomment-1171543602):

- Ability to generate network config for Hetzner Cloud (passing `PROVIDER=hetznercloud`)
- Setting `networking.defaultGateway6.interface` in `networking.nix`

I tested the changes on Hetzner (Debian 11) and it works - I can ping:

![image](https://user-images.githubusercontent.com/36413794/210410797-dcb39568-8d3c-4473-8ac5-77d1ad1bbef3.png)

Before the changes:

![image](https://user-images.githubusercontent.com/36413794/210410881-b559cdad-51c8-4863-9011-f3f95f2f6a5c.png)
