### PR TITLE
Update NixOS version for Hetzner

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ When creating a server provide the following script as "User data":
 ```
 #!/bin/sh
 
-curl https://raw.githubusercontent.com/elitak/nixos-infect/master/nixos-infect | NIX_CHANNEL=nixos-22.05 bash 2>&1 | tee /tmp/infect.log
+curl https://raw.githubusercontent.com/elitak/nixos-infect/master/nixos-infect | NIX_CHANNEL=nixos-22.11 bash 2>&1 | tee /tmp/infect.log
 ```
 
 #### Tested on


### PR DESCRIPTION
Use the current stable NixOS version in the installation instructions for Hetzner.

I've tested this with a new server instance.