### PR TITLE
Do not add channel when installing Nix

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -313,7 +313,7 @@ infect() {
   #addgroup nixbld -g 30000 || true
   #for i in {1..10}; do adduser -DH -G nixbld nixbld$i || true; done
 
-  curl -L https://nixos.org/nix/install | sh
+  curl -L https://nixos.org/nix/install | sh -s -- --no-channel-add
 
   # shellcheck disable=SC1090
   source ~/.nix-profile/etc/profile.d/nix.sh


### PR DESCRIPTION
The official Nix installer will [add `nixpkgs-unstable` channel](https://github.com/NixOS/nix/blob/2ef99cd10489929a755831251c3fad8f3df2faeb/scripts/install-nix-from-closure.sh#L204-L215) unless run with `--no-channel-add` option. This seems unnecessary and only slows down installation as nixos-infect is adding channels just below.