### PR TITLE
fix: do not move ESP to /boot.  Instead leave it at /boot/efi.

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -47,12 +47,13 @@ EOF
 
   if isEFI; then
     bootcfg=$(cat << EOF
+  boot.loader.efi.efiSysMountPoint = "/boot/efi";
   boot.loader.grub = {
     efiSupport = true;
     efiInstallAsRemovable = true;
     device = "nodev";
   };
-  fileSystems."/boot" = { device = "$esp"; fsType = "vfat"; };
+  fileSystems."/boot/efi" = { device = "$esp"; fsType = "vfat"; };
 EOF
 )
   else
@@ -356,9 +357,9 @@ infect() {
 
   mv -v /boot /boot.bak || { cp -a /boot /boot.bak ; rm -rf /boot/* ; umount /boot ; }
   if isEFI; then
-    mkdir -p /boot
-    mount "$esp" /boot
-    find /boot -depth ! -path /boot -exec rm -rf {} +
+    mkdir -p /boot/efi
+    mount "$esp" /boot/efi
+    find /boot/efi -depth ! -path /boot/efi -exec rm -rf {} +
   fi
   /nix/var/nix/profiles/system/bin/switch-to-configuration boot
 }


### PR DESCRIPTION
This seems to be a safer approach for infecting UEFI-based hosts.  Test case:

1. Set up a OCI Instance with Oracle or Ubuntu
  i) Notice it has a 100 MB ESP partition
  ii) OOTB nixos-infect takes this partition over and remounts it at /boot
  iii) A single kernel/initramfs pair takes up most of this space
  iv) Further use of the "nixos-infect"-ed system will likely lead to breakages due to running out of kernel/initramfs storage space.

To work around this, this PR uses the ESP partition strictly for ESP activities.  Kernels and initramfs instead live on /boot within the rootfs.  This should eliminate the space constraints on small ESP partitions that were being repurposed for kernel/initramfs.