### PR TITLE
Continue with next file if no keys are found

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -21,6 +21,7 @@ makeConf() {
   for trypath in /root/.ssh/authorized_keys /home/$SUDO_USER/.ssh/authorized_keys $HOME/.ssh/authorized_keys; do
       [[ -r "$trypath" ]] \
       && keys=$(sed -E 's/^.*((ssh|ecdsa)-[^[:space:]]+)[[:space:]]+([^[:space:]]+)([[:space:]]*.*)$/\1 \3\4/' "$trypath") \
+      && [[ ! -z "$keys" ]] \
       && break
   done
   local network_import=""


### PR DESCRIPTION
If a `authorized_keys` file is empty or does not contain valid keys the rest of the illegible files are skipped. This change will make sure all files are checked until at least one key is found.