### PR TITLE
Fix DigitalOcean installation

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -40,7 +40,7 @@ makeConf() {
   networking.domain = "$(hostname -d)";
   services.openssh.enable = true;
   users.users.root.openssh.authorizedKeys.keys = [$(while read -r line; do echo -n "
-    \"$line\" "; done <<< "$keys")
+    ''$line'' "; done <<< "$keys")
   ];
 }
 EOF


### PR DESCRIPTION
DigitalOcean now adds an SSH key containing double-quotes, which breaks nixos-infect.  This commit fixes this by using two single-quotes instead of a double-quote to wrap the SSH public key lines.