### PR TITLE
eth1 does not get configured on DigitalOcean when using a VPC

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -109,7 +109,7 @@ makeNetworkingConf() {
     eth1_ip4s=$(ip address show dev "$eth1_name" | grep 'inet ' | sed -r 's|.*inet ([0-9.]+)/([0-9]+).*|{ address="\1"; prefixLength=\2; }|')
     eth1_ip6s=$(ip address show dev "$eth1_name" | grep 'inet6 ' | sed -r 's|.*inet6 ([0-9a-f:]+)/([0-9]+).*|{ address="\1"; prefixLength=\2; }|' || '')
     ether1=$(ip address show dev "$eth1_name" | grep link/ether | sed -r 's|.*link/ether ([0-9a-f:]+) .*|\1|')
-    interfaces1=<< EOF
+    interfaces1=$(cat << EOF
       $eth1_name = {
         ipv4.addresses = [$(for a in "${eth1_ip4s[@]}"; do echo -n "
           $a"; done)
@@ -118,6 +118,7 @@ makeNetworkingConf() {
           $a"; done)
         ];
 EOF
+)
     extraRules1="ATTR{address}==\"${ether1}\", NAME=\"${eth1_name}\""
   else
     interfaces1=""

--- a/nixos-infect
+++ b/nixos-infect
@@ -117,6 +117,7 @@ makeNetworkingConf() {
         ipv6.addresses = [$(for a in "${eth1_ip6s[@]}"; do echo -n "
           $a"; done)
         ];
+        };
 EOF
 )
     extraRules1="ATTR{address}==\"${ether1}\", NAME=\"${eth1_name}\""


### PR DESCRIPTION
When spinning up two resources on the same VPC, my eth1 interface (the VPC's private IP range) did not get configured. Have tested on 15 Jul 2023 on DO and it has fixed my issue.