### PR TITLE
Fix SSH keys formatting

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -42,7 +42,7 @@ makeConf() {
   services.openssh.enable = true;
   users.users.root.openssh.authorizedKeys.keys = [$(while read -r line; do
     line=$(echo -n "$line" | sed 's/\r//g')
-    trimmed_line=$(echo -n "$line" | tr -d '[:space:]')
+    trimmed_line=$(echo -n "$line" | xargs)
     echo -n "''$trimmed_line'' "
   done <<< "$keys")];
 }


### PR DESCRIPTION
As described in  issue #170 , it seems that trimming a key string removes too many spaces. The authorized keys format assumes that each line is arguments separated by a space. Xargs should leave it in this format, removing unnecessary whitespace characters.