### PR TITLE
Add provider autodetection for hetzner

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -4,6 +4,12 @@
 
 set -e -o pipefail
 
+autodetectProvider() {
+  if [ -e /etc/hetzner-build ]; then
+    PROVIDER="hetznercloud"
+  fi
+}
+
 makeConf() {
   # Skip everything if main config already present
   [[ -e /etc/nixos/configuration.nix ]] && return 0
@@ -373,6 +379,10 @@ infect() {
   fi
   /nix/var/nix/profiles/system/bin/switch-to-configuration boot
 }
+
+if [ ! -v PROVIDER ]; then
+  autodetectProvider
+fi
 
 [ "$PROVIDER" = "digitalocean" ] && doNetConf=y # digitalocean requires detailed network config to be generated
 [ "$PROVIDER" = "lightsail" ] && newrootfslabel="nixos"


### PR DESCRIPTION
The idea is to automate provider detection when using curl and not cloud-init, since most providers add their own easily-detectable shenanigans

(The alternative would be to warn about setting PROVIDER manually, but that is more effort for the user)

Ref: https://github.com/elitak/nixos-infect/issues/173#issuecomment-1745921769

This was tested on CAX11