### PR TITLE
Add oraclecloud PROVIDER to fix small /boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,17 @@ e2fsck: Get a newer version of e2fsck
 Using an older Ubuntu version fixes this issue.
 
 ### Oracle Cloud Infrastructure
-Tested for both VM.Standard.E2.1.Micro (x86) and VM.Standard.A1.Flex (AArch64) instances.
+Tested for both VM.Standard.E2.1.Micro (x86) and VM.Standard.A1.Flex (AArch64) instances. 
+
+Standard images come with a small 100MB `/boot/efi` partition, that is too small to hold the kernel.
+Make sure to set `PROVIDER=oraclecloud` to avoid mounting that partition as `/boot`.
+
+```
+curl https://raw.githubusercontent.com/elitak/nixos-infect/master/nixos-infect | PROVIDER=oraclecloud NIX_CHANNEL=nixos-22.11 bash
+```
 
 #### Tested on
+
 |Distribution|       Name      | Status    | test date|   Shape  |
 |------------|-----------------|-----------|----------|----------|
 |Oracle Linux| 7.9             |**success**|2021-05-31|          |
@@ -215,15 +223,17 @@ Tested for both VM.Standard.E2.1.Micro (x86) and VM.Standard.A1.Flex (AArch64) i
 |Oracle Linux| 8.0             | -failure- |2022-04-19| free amd |
 |CentOS      | 8.0             | -failure- |2022-04-19| free amd |
 |Oracle Linux| 7.9[1]          |**success**|2022-04-19| free amd |
-|Ubuntu      | 22.04           |**success**|2022-11-13| free arm |
-|Oracle Linux| 9.1[2]          |**success**|2023-03-29| free arm |
-|Oracle Linux| 8.7[3]          |**success**|2023-06-06| free amd |
+|Ubuntu      | 22.04[2]        |**success**|2023-11-16| free arm |
+|Ubuntu      | 22.04[2]        |**success**|2023-11-16| free amd |
+|Oracle Linux| 9.1[3]          |**success**|2023-03-29| free arm |
+|Oracle Linux| 8.7[4]          |**success**|2023-06-06| free amd |
 |AlmaLinux OS| 9.2.20230516    |**success**|2023-07-05| free arm |
 
     [1] The Oracle 7.9 layout has 200Mb for /boot 8G for swap
     PR#100 Adopted 8G Swap device
-    [2] OL9.1 had 2GB /boot, 100MB /boot/efi (nixos used as /boot) and swapfile
-    [3] Both 22.11 and 23.05 failed to boot, but installing 22.05 and then upgrading
+    [2] Ubuntu 22.04 Minimal has the best layout: 100MB /boot/efi, no boot, no swap
+    [3] OL9.1 had 2GB /boot (unused), 100MB /boot/efi and swapfile
+    [4] Both 22.11 and 23.05 failed to boot, but installing 22.05 and then upgrading
     worked out as intended.
 
 ### Aliyun ECS

--- a/nixos-infect
+++ b/nixos-infect
@@ -50,12 +50,13 @@ EOF
 
   if isEFI; then
     bootcfg=$(cat << EOF
+  boot.loader.efi.efiSysMountPoint = "$espMountPoint";
   boot.loader.grub = {
     efiSupport = true;
     efiInstallAsRemovable = true;
     device = "nodev";
   };
-  fileSystems."/boot" = { device = "$esp"; fsType = "vfat"; };
+  fileSystems."$espMountPoint" = { device = "$esp"; fsType = "vfat"; };
 EOF
 )
   else
@@ -367,15 +368,17 @@ infect() {
 
   mv -v /boot /boot.bak || { cp -a /boot /boot.bak ; rm -rf /boot/* ; umount /boot ; }
   if isEFI; then
-    mkdir -p /boot
-    mount "$esp" /boot
-    find /boot -depth ! -path /boot -exec rm -rf {} +
+    mkdir -p "$espMountPoint"
+    mount "$esp" "$espMountPoint"
+    find "$espMountPoint" -depth ! -path "$espMountPoint" -exec rm -rf {} +
   fi
   /nix/var/nix/profiles/system/bin/switch-to-configuration boot
 }
 
+espMountPoint="/boot"
 [ "$PROVIDER" = "digitalocean" ] && doNetConf=y # digitalocean requires detailed network config to be generated
 [ "$PROVIDER" = "lightsail" ] && newrootfslabel="nixos"
+[ "$PROVIDER" = "oraclecloud" ] && espMountPoint="/boot/efi"
 if [[ "$PROVIDER" = "digitalocean" ]] || [[ "$PROVIDER" = "servarica" ]] || [[ "$PROVIDER" = "hetznercloud" ]]; then
 	doNetConf=y # some providers require detailed network config to be generated
 fi


### PR DESCRIPTION
This is an alternative to https://github.com/elitak/nixos-infect/pull/145, to fix infect on Oracle Cloud.

All of the provided image I tested (Ubuntu, Oracle 8, Oracle 9, Alma Linux) have a 100MB `/boot/efi` partition, that nixos-infect takes over as `/boot`. The partition is too small to hold two kernels, and subsequent NixOS upgrades fail.

Tested on both ARM64 and AMD64 with `curl https://raw.githubusercontent.com/xvello/nixos-infect/oracle/nixos-infect | PROVIDER=oraclecloud NO_SWAP=1 bash -x`.


An alternative approach would be to modify `findESP()` to keep track of the folder it autodetected, to reuse that path. The code change for that was more intrusive, and could break infect on another topology.

# Partition layouts

For reference, here are the partition layouts for VMs in Oracle Cloud

### Canonical Ubuntu 22.04 Minimal (aarch64 and amd64)

This is the best layout I found so far, only 100M of EFI, the rest as ext4 root. This is the one we should recommend for new users:

```
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda1        45G  1.1G   44G   3% /
/dev/sda15       98M  6.3M   92M   7% /boot/efi
```

### Oracle 8 (default)

This layout is very wasteful, leaving 11G unused after infect (1G of `/boot`, 10G of `/var/oled`):

```
Filesystem                  Size  Used Avail Use% Mounted on
/dev/mapper/ocivolume-root   36G  8.8G   27G  25% /
/dev/sda2                   924M  319M  606M  35% /boot
/dev/mapper/ocivolume-oled   10G  108M  9.8G   2% /var/oled
/dev/sda1                   100M  6.2M   94M   7% /boot/efi
```