### PR TITLE
readme/DO: Mark ubuntu 23.10 as failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ runcmd:
 |Ubuntu      |20.04 x64        |**success**|2022-03-23|
 |Ubuntu      |22.04 x64        |**success**|2023-06-05|
 |Ubuntu      |22.10 x64        | _failure_ |2023-06-05|
+|Ubuntu      |23.10 x64        | _failure_ |2023-11-16|
 
 ### Vultr
 To set up a NixOS Vultr server, instantiate an Ubuntu box with the following "Cloud-Init User-Data":


### PR DESCRIPTION
The user data approach dropped me in an inconsistent state. Nix installed, but other files were unaffected.

Ubuntu 22.04 (LTS) x64 worked perfectly, on the other hand.