### PR TITLE
chore: Rename boot.cleanTmpDir to boot.tmp.cleanOnBoot

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -35,7 +35,7 @@ makeConf() {
     $NIXOS_IMPORT
   ];
 
-  boot.cleanTmpDir = true;
+  boot.tmp.cleanOnBoot = true;
   zramSwap.enable = ${zramswap};
   networking.hostName = "$(hostname -s)";
   networking.domain = "$(hostname -d)";


### PR DESCRIPTION
Fixes a warning in 23.05