### PR TITLE
Fix option boot.cleanTmpDir has been renamed

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -35,7 +35,7 @@ makeConf() {
     $NIXOS_IMPORT
   ];
 
-  boot.cleanTmpDir = true;
+  boot.tmp.cleanOnBoot = true;
   zramSwap.enable = ${zramswap};
   networking.hostName = "$(hostname -s)";
   networking.domain = "$(hostname -d)";


### PR DESCRIPTION
`nixos-rebuild switch` spits out a warning:

```bash
trace: warning: The option `boot.cleanTmpDir' defined in `/etc/nixos/configuration.nix' has been renamed to `boot.tmp.cleanOnBoot'.
```

This PR renames that option to fix the warning.