### PR TITLE
change lightsail boot device to /dev/nvme0n1

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -92,6 +92,7 @@ makeLightsailConf() {
 { config, pkgs, modulesPath, ... }:
 {
   imports = [ "\${modulesPath}/virtualisation/amazon-image.nix" ];
+  boot.loader.grub.device = lib.mkForce "/dev/nvme0n1";
 }
 EOF
 }

--- a/nixos-infect
+++ b/nixos-infect
@@ -89,7 +89,7 @@ EOF
 makeLightsailConf() {
   mkdir -p /etc/nixos
   cat > /etc/nixos/configuration.nix << EOF
-{ config, pkgs, modulesPath, ... }:
+{ config, pkgs, modulesPath, lib, ... }:
 {
   imports = [ "\${modulesPath}/virtualisation/amazon-image.nix" ];
   boot.loader.grub.device = lib.mkForce "/dev/nvme0n1";


### PR DESCRIPTION
This pull request closes #183. I have already tested this change in AWS Lightsail with Ubuntu 22.04.

The boot device has been changed to:
```
NAME         MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
...
nvme0n1      259:0    0    40G  0 disk
├─nvme0n1p1  259:1    0  39.9G  0 part /
├─nvme0n1p14 259:2    0     4M  0 part
└─nvme0n1p15 259:3    0   106M  0 part /boot/efi
```


After rebooting the instance, the NixOS has been installed successfully.
```
Linux ip-<redact>.ap-southeast-1.compute.internal 5.15.119 #1-NixOS SMP Wed Jun 28 08:29:53 UTC 2023 x86_64 GNU/Linux
``` 