### PR TITLE
Add option to use a custom nix install URL

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -317,8 +317,8 @@ infect() {
   # TODO use addgroup and adduser as fallbacks
   #addgroup nixbld -g 30000 || true
   #for i in {1..10}; do adduser -DH -G nixbld nixbld$i || true; done
-
-  curl -L https://nixos.org/nix/install | sh -s -- --no-channel-add
+  NIX_INSTALL_URL="${NIX_INSTALL_URL:-https://nixos.org/nix/install}"
+  curl -L "${NIX_INSTALL_URL}" | sh -s -- --no-channel-add
 
   # shellcheck disable=SC1090
   source ~/.nix-profile/etc/profile.d/nix.sh


### PR DESCRIPTION
This change allow users to specify a custom nix install URL to use another nix version than the latest stable or to use another installer script.