### PR TITLE
docs: add successfull install status on oracle linux 8.10 aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Tested for both VM.Standard.E2.1.Micro (x86) and VM.Standard.A1.Flex (AArch64) i
 |Ubuntu      | 22.04           |**success**|2022-11-13| free arm |
 |Oracle Linux| 9.1[2]          |**success**|2023-03-29| free arm |
 |Oracle Linux| 8.7[3]          |**success**|2023-06-06| free amd |
+|Oracle Linux| 8.10            |**success**|2024-06-03| free arm |
 |AlmaLinux OS| 9.2.20230516    |**success**|2023-07-05| free arm |
 
     [1] The Oracle 7.9 layout has 200Mb for /boot 8G for swap


### PR DESCRIPTION
- tested with 23.05 without any issues on a vanilla installation