### PR TITLE
Work around missing nixbld group in sandbox

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -41,6 +41,9 @@ makeConf() {
     $NIXOS_IMPORT
   ];
 
+  # Workaround for https://github.com/NixOS/nix/issues/8502
+  services.logrotate.checkConfig = false;
+
   boot.tmp.cleanOnBoot = true;
   zramSwap.enable = ${zramswap};
   networking.hostName = "$(hostname -s)";


### PR DESCRIPTION
Works around the bug with missing nixbld group in sandbox by disabling checkConf for logrotate. This is apparently still a problem even though this PR https://github.com/NixOS/nixpkgs/pull/166992 is closed.

Before:

```
building '/nix/store/7j5qfkjxw2fzxlvmjkwd8l3kj0wsbbbc-locale.conf.drv'...
building '/nix/store/9lsdh1k7r4whprrk6n8mbg4sxaviwrnf-localhost-hosts.drv'...
building '/nix/store/l8i8rarv8bn0yrfa7l463xx24farcwmg-login.defs.drv'...
building '/nix/store/6bgq3jzld7f2hv01zffw506nbn6jwywy-login.pam.drv'...
building '/nix/store/9zlnjv3i3kp0g5x3x1b1pwa2pmv6ni8g-logrotate.conf.drv'...
/nix/store/l9mg93sgx50y88p5rr6x1vib6j1rjsds-coreutils-9.1/bin/id: cannot find name for group ID 30000
building '/nix/store/7j5qfkjxw2fzxlvmjkwd8l3kj0wsbbbc-locale.conf.drv'...
building '/nix/store/9lsdh1k7r4whprrk6n8mbg4sxaviwrnf-localhost-hosts.drv'...
building '/nix/store/l8i8rarv8bn0yrfa7l463xx24farcwmg-login.defs.drv'...
building '/nix/store/6bgq3jzld7f2hv01zffw506nbn6jwywy-login.pam.drv'...
building '/nix/store/9zlnjv3i3kp0g5x3x1b1pwa2pmv6ni8g-logrotate.conf.drv'...
/nix/store/l9mg93sgx50y88p5rr6x1vib6j1rjsds-coreutils-9.1/bin/id: cannot find name for group ID 30000
root@racknerd-1d8012:~#
```

after:

```
deleting unused links...
note: currently hard linking saves -0.00 MiB
684 store paths deleted, 48.71 MiB freed
+ [[ -L /etc/resolv.conf ]]
+ '[' -n '' ']'
+ touch /etc/NIXOS
+ echo etc/nixos
+ echo etc/resolv.conf
+ echo root/.nix-defexpr/channels
+ cd /
+ ls etc/ssh/ssh_host_dsa_key etc/ssh/ssh_host_dsa_key.pub etc/ssh/ssh_host_rsa_key etc/ssh/ssh_host_rsa_key.pub
+ rm -rf /boot.bak
+ isEFI
+ '[' -d /sys/firmware/efi ']'
+ mv -v /boot /boot.bak
renamed '/boot' -> '/boot.bak'
+ isEFI
+ '[' -d /sys/firmware/efi ']'
+ /nix/var/nix/profiles/system/bin/switch-to-configuration boot
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = (unset),
        LC_ALL = (unset),
        LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
updating GRUB 2 menu...
installing the GRUB 2 boot loader on /dev/vda...
Installing for i386-pc platform.
Installation finished. No error reported.
+ [[ -z true ]]
+ [[ -z '' ]]
+ reboot
root@racknerd#
```
