### PR TITLE
Add Webdock to hosts that work, with doNetConf

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,8 @@ On RackNerd's Ubuntu 20.04, there's no `curl` by default, so `wget -O-` needs to
 Remember that you can not add SSH keys to the root user trough the web interface,
 manually add a public key to `/root/.ssh/authorized_keys`.
 
+Make sure to set `PROVIDER=webdock`
+
 #### Tested on
 |Distribution| Name   | Status    | test date|
 |------------|--------|-----------|----------|

--- a/README.md
+++ b/README.md
@@ -363,3 +363,13 @@ On RackNerd's Ubuntu 20.04, there's no `curl` by default, so `wget -O-` needs to
 |------------|--------|----------------------------|------------|
 |AlmaLinux   | 8      | _failure (`tar` missing)_  | 2023-08-29 |
 |Ubuntu      | 20.04  | **success**                | 2023-08-29 |
+
+### Webdock
+Remember that you can not add SSH keys to the root user trough the web interface,
+manually add a public key to `/root/.ssh/authorized_keys`.
+
+#### Tested on
+|Distribution| Name   | Status    | test date|
+|------------|--------|-----------|----------|
+|Ubuntu      | 20.04  | success   |2024-10-26|
+|Ubuntu      | 22.04  | success   |2024-10-26|

--- a/nixos-infect
+++ b/nixos-infect
@@ -388,7 +388,7 @@ fi
 
 [ "$PROVIDER" = "digitalocean" ] && doNetConf=y # digitalocean requires detailed network config to be generated
 [ "$PROVIDER" = "lightsail" ] && newrootfslabel="nixos"
-if [[ "$PROVIDER" = "digitalocean" ]] || [[ "$PROVIDER" = "servarica" ]] || [[ "$PROVIDER" = "hetznercloud" ]]; then
+if [[ "$PROVIDER" = "digitalocean" ]] || [[ "$PROVIDER" = "servarica" ]] || [[ "$PROVIDER" = "hetznercloud" ]] || [[ "$PROVIDER" = "webdock" ]]; then
 	doNetConf=y # some providers require detailed network config to be generated
 fi
 


### PR DESCRIPTION
Tested on Ubuntu 22.04 and 20.04

Only works with `doNetConf=y`. Also added this when running with `PROVIDER=webdock`