### PR TITLE
Remove a redundant duplicate check for DigitalOcean

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -386,7 +386,6 @@ if [ ! -v PROVIDER ]; then
   autodetectProvider
 fi
 
-[ "$PROVIDER" = "digitalocean" ] && doNetConf=y # digitalocean requires detailed network config to be generated
 [ "$PROVIDER" = "lightsail" ] && newrootfslabel="nixos"
 if [[ "$PROVIDER" = "digitalocean" ]] || [[ "$PROVIDER" = "servarica" ]] || [[ "$PROVIDER" = "hetznercloud" ]]; then
 	doNetConf=y # some providers require detailed network config to be generated


### PR DESCRIPTION
This check is done again below, with other providers.