### PR TITLE
Update README.md to document `doNetConf` env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Any errors halt execution.
 A failure will leave the system in an inconsistent state,
 and so it is advised to run with `bash -x`.
 
+If you're running this script and networking does not come up after reboot, try setting `doNetConf=y` environment variable when executing the script. This generates the network configuration automatically.
+
 ## Hoster notes:
 ### Digital Ocean
 You may utilize Digital Ocean's "user data" mechanism (found in the Web UI or HTTP API),


### PR DESCRIPTION
I initially tried using the script as in the example given in the README, and it didn’t work right away.

It took me some time to figure out the issue, which turned out to be something quite simple. The problem was that I needed to set the `doNetConf` environment variable to enable network configuration.

I thought it would be helpful to mention this in the `README` just in case others run into the same issue. This small addition could save people time and frustration.