### PR TITLE
Support for Layer7 Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,3 +363,16 @@ On RackNerd's Ubuntu 20.04, there's no `curl` by default, so `wget -O-` needs to
 |------------|--------|----------------------------|------------|
 |AlmaLinux   | 8      | _failure (`tar` missing)_  | 2023-08-29 |
 |Ubuntu      | 20.04  | **success**                | 2023-08-29 |
+
+
+### Layer7
+
+```command
+# wget -O- https://raw.githubusercontent.com/elitak/nixos-infect/master/nixos-infect | PROVIDER=layer7 NIX_CHANNEL=nixos-23.05 bash -x
+```
+
+#### Tested on
+|Distribution| Name   | Status                     |   test date|
+|------------|--------|----------------------------|------------|
+|Ubuntu      | 20.04  | **success**                | 2025-05-27 |
+|Ubuntu      | 22.04  | **success**                | 2025-05-27 |

--- a/nixos-infect
+++ b/nixos-infect
@@ -388,7 +388,7 @@ fi
 
 [ "$PROVIDER" = "digitalocean" ] && doNetConf=y # digitalocean requires detailed network config to be generated
 [ "$PROVIDER" = "lightsail" ] && newrootfslabel="nixos"
-if [[ "$PROVIDER" = "digitalocean" ]] || [[ "$PROVIDER" = "servarica" ]] || [[ "$PROVIDER" = "hetznercloud" ]]; then
+if [[ "$PROVIDER" = "digitalocean" ]] || [[ "$PROVIDER" = "servarica" ]] || [[ "$PROVIDER" = "hetznercloud" ]] || [[ "$PROVIDER" = "layer7" ]]; then
 	doNetConf=y # some providers require detailed network config to be generated
 fi
 


### PR DESCRIPTION
This PR documents tests for Layer7 and updates the `nixos-infect` script to support Layer7 out of the box.