### PR TITLE
Support RHEL-based distros

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -300,9 +300,9 @@ checkEnv() {
   which curl  || fakeCurlUsingWget \
               || (which apt-get && apt-get update && apt-get install -y curl) \
               || true
-  # which tar   || (which yum && yum install -y tar) \
-  #             || (which apt-get && apt-get update && apt-get install -y tar) \
-  #             || true
+  which tar || (which yum && yum install -y tar) \
+            || (which apt-get && apt-get update && apt-get install -y tar) \
+            || true
 
   req curl || req wget || { echo "ERROR: Missing both curl and wget";  return 1; }
   req bzcat            || { echo "ERROR: Missing bzcat";               return 1; }
@@ -312,7 +312,7 @@ checkEnv() {
   req ip               || { echo "ERROR: Missing ip";                  return 1; }
   req awk              || { echo "ERROR: Missing awk";                 return 1; }
   req cut || req df    || { echo "ERROR: Missing coreutils (cut, df)"; return 1; }
-  # req tar              || { echo "ERROR: Missing tar";                 return 1; }
+  req tar              || { echo "ERROR: Missing tar";                 return 1; }
 
   # On some versions of Oracle Linux these have the wrong permissions,
   # which stops sshd from starting when NixOS boots


### PR DESCRIPTION
This PR adds compatibility with RHEL-based distros.
- the package xz-utils should be called xz
- some newer releases don't have tar by default (required by NixOS installer script), specifically CentOS Stream 9

If you are interested I'd be happy to discuss how we could add this as a CI-test suite. I haven't published the test setup, but could do this if you want to be able to run tests manually. The test suite requires [nix-infra](https://github.com/jhsware/nix-infra) and a Hetzner Cloud account (€ 3.49/mo for the cheapest cloud server).

UPDATE: I updated the test script and expanded list of tested distros.

Tested on Hetzner Cloud with [nix-infra](https://github.com/jhsware/nix-infra):

Base Image | Verified System | Provisioning Time | Status
-- | -- | -- | --
ubuntu-22.04 | Ubuntu 22.04.5 LTS | 2m 37s | ✓
ubuntu-24.04 | Ubuntu 24.04.3 LTS | 2m 22s | ✓
debian-11 | Debian GNU/Linux 11 (bullseye) | 2m 00s | ✓
debian-12 | Debian GNU/Linux 12 (bookworm) | 2m 08s | ✓
centos-stream-9 | CentOS Stream 9 | 2m 06s | ✓
centos-stream-10 | CentOS Stream 10 (Coughlan) | 2m 11s | ✓
rocky-9 | Rocky Linux 9.7 (Blue Onyx) | 2m 11s | ✓
rocky-10 | Rocky Linux 10.1 (Red Quartz) | 2m 18s | ✓
alma-9 | AlmaLinux 9.7 (Moss Jungle Cat) | 2m 15s | ✓
alma-10 | AlmaLinux 10.1 (Heliotrope Lion) | 2m 11s | ✓
opensuse-15 | openSUSE Leap 15.6 | 2m 00s | ✓

Test output:
```
[nix-shell:~/DEV/nix-infra/__integration__/provisioning]$ ./test-provisioning.sh convert --env=../../.env-integration-tests 
workdir: .
path to env: ../../.env-integration-tests
Identity added: ./ssh/nixinfra-machine (sebastian@urbantalk.se)
*** Rebuild testnode001 with ubuntu-22.04 ***
Wait for rebuild to complete... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ - Action completed successfully!
Allow to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
Verify installed system:
Ubuntu 22.04.5 LTS
*** Provisioning NixOS 25.05 ***
- ************* SPAWNING NODES *************
- Node testnode001 already exists, skipping!
- ssh: !
- Converting to NixOS... 25.05
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- ssh: .....!
- Done!
DEBUG: + testnode001: NixOS
Allow rebuild to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
NixOS 25.05 (Warbler)
******************************************
==========================================
Running Fleet Health Checks
==========================================
Checking NixOS...
testnode001: Linux testnode001 6.12.62 #1-NixOS SMP PREEMPT_DYNAMIC Fri Dec 12 17:37:22 UTC 2025 x86_64 GNU/Linux testnode001:
  ✓ nixos: ok (testnode001)
==========================================
Health checks: PASSED
Base image: ubuntu-22.04
Provisioning time: 00h:02m:37s
Total test time: 00h:03m:29s
******************************************
*** Rebuild testnode001 with ubuntu-24.04 ***
Wait for rebuild to complete... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ - Action completed successfully!
Allow to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
Verify installed system:
Ubuntu 24.04.3 LTS
*** Provisioning NixOS 25.05 ***
- ************* SPAWNING NODES *************
- Node testnode001 already exists, skipping!
- ssh: !
- Converting to NixOS... 25.05
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- ssh: ......!
- Done!
DEBUG: + testnode001: NixOS
Allow rebuild to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
NixOS 25.05 (Warbler)
******************************************
==========================================
Running Fleet Health Checks
==========================================
Checking NixOS...
testnode001: Linux testnode001 6.12.62 #1-NixOS SMP PREEMPT_DYNAMIC Fri Dec 12 17:37:22 UTC 2025 x86_64 GNU/Linux testnode001:
  ✓ nixos: ok (testnode001)
==========================================
Health checks: PASSED
Base image: ubuntu-24.04
Provisioning time: 00h:02m:22s
Total test time: 00h:03m:13s
******************************************
*** Rebuild testnode001 with debian-11 ***
Wait for rebuild to complete... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ - Action completed successfully!
Allow to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
Verify installed system:
Debian GNU/Linux 11 (bullseye)
*** Provisioning NixOS 25.05 ***
- ************* SPAWNING NODES *************
- Node testnode001 already exists, skipping!
- ssh: !
- Converting to NixOS... 25.05
++++++++++++
- ssh: ......!
- Done!
DEBUG: + testnode001: NixOS
Allow rebuild to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
NixOS 25.05 (Warbler)
******************************************
==========================================
Running Fleet Health Checks
==========================================
Checking NixOS...
testnode001: Linux testnode001 6.12.62 #1-NixOS SMP PREEMPT_DYNAMIC Fri Dec 12 17:37:22 UTC 2025 x86_64 GNU/Linux testnode001:
  ✓ nixos: ok (testnode001)
==========================================
Health checks: PASSED
Base image: debian-11
Provisioning time: 00h:02m:00s
Total test time: 00h:02m:54s
******************************************
*** Rebuild testnode001 with debian-12 ***
Wait for rebuild to complete... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ - Action completed successfully!
Allow to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
Verify installed system:
Debian GNU/Linux 12 (bookworm)
*** Provisioning NixOS 25.05 ***
- ************* SPAWNING NODES *************
- Node testnode001 already exists, skipping!
- ssh: !
- Converting to NixOS... 25.05
+++++++++++++++
- ssh: .......!
- Done!
DEBUG: + testnode001: NixOS
Allow rebuild to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
NixOS 25.05 (Warbler)
******************************************
==========================================
Running Fleet Health Checks
==========================================
Checking NixOS...
testnode001: Linux testnode001 6.12.62 #1-NixOS SMP PREEMPT_DYNAMIC Fri Dec 12 17:37:22 UTC 2025 x86_64 GNU/Linux testnode001:
  ✓ nixos: ok (testnode001)
==========================================
Health checks: PASSED
Base image: debian-12
Provisioning time: 00h:02m:08s
Total test time: 00h:03m:02s
******************************************
*** Rebuild testnode001 with centos-stream-9 ***
Wait for rebuild to complete... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ - Action completed successfully!
Allow to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
Verify installed system:
CentOS Stream 9
*** Provisioning NixOS 25.05 ***
- ************* SPAWNING NODES *************
- Node testnode001 already exists, skipping!
- ssh: !
- Converting to NixOS... 25.05
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- ssh: .....!
- Done!
DEBUG: + testnode001: NixOS
Allow rebuild to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
NixOS 25.05 (Warbler)
******************************************
==========================================
Running Fleet Health Checks
==========================================
Checking NixOS...
testnode001: Linux testnode001 6.12.62 #1-NixOS SMP PREEMPT_DYNAMIC Fri Dec 12 17:37:22 UTC 2025 x86_64 GNU/Linux testnode001:
  ✓ nixos: ok (testnode001)
==========================================
Health checks: PASSED
Base image: centos-stream-9
Provisioning time: 00h:02m:06s
Total test time: 00h:02m:58s
******************************************
*** Rebuild testnode001 with centos-stream-10 ***
Wait for rebuild to complete... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ - Action completed successfully!
Allow to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
Verify installed system:
CentOS Stream 10 (Coughlan)
*** Provisioning NixOS 25.05 ***
- ************* SPAWNING NODES *************
- Node testnode001 already exists, skipping!
- ssh: !
- Converting to NixOS... 25.05
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- ssh: .....!
- Done!
DEBUG: + testnode001: NixOS
Allow rebuild to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
NixOS 25.05 (Warbler)
******************************************
==========================================
Running Fleet Health Checks
==========================================
Checking NixOS...
testnode001: Linux testnode001 6.12.62 #1-NixOS SMP PREEMPT_DYNAMIC Fri Dec 12 17:37:22 UTC 2025 x86_64 GNU/Linux testnode001:
  ✓ nixos: ok (testnode001)
==========================================
Health checks: PASSED
Base image: centos-stream-10
Provisioning time: 00h:02m:11s
Total test time: 00h:03m:04s
******************************************
*** Rebuild testnode001 with rocky-9 ***
Wait for rebuild to complete... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ - Action completed successfully!
Allow to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
Verify installed system:
Rocky Linux 9.7 (Blue Onyx)
*** Provisioning NixOS 25.05 ***
- ************* SPAWNING NODES *************
- Node testnode001 already exists, skipping!
- ssh: !
- Converting to NixOS... 25.05
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- ssh: .....!
- Done!
DEBUG: + testnode001: NixOS
Allow rebuild to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
NixOS 25.05 (Warbler)
******************************************
==========================================
Running Fleet Health Checks
==========================================
Checking NixOS...
testnode001: Linux testnode001 6.12.62 #1-NixOS SMP PREEMPT_DYNAMIC Fri Dec 12 17:37:22 UTC 2025 x86_64 GNU/Linux testnode001:
  ✓ nixos: ok (testnode001)
==========================================
Health checks: PASSED
Base image: rocky-9
Provisioning time: 00h:02m:11s
Total test time: 00h:03m:02s
******************************************
*** Rebuild testnode001 with rocky-10 ***
Wait for rebuild to complete... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ - Action completed successfully!
Allow to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
Verify installed system:
Rocky Linux 10.1 (Red Quartz)
*** Provisioning NixOS 25.05 ***
- ************* SPAWNING NODES *************
- Node testnode001 already exists, skipping!
- ssh: !
- Converting to NixOS... 25.05
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- ssh: ......!
- Done!
DEBUG: + testnode001: NixOS
Allow rebuild to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
NixOS 25.05 (Warbler)
******************************************
==========================================
Running Fleet Health Checks
==========================================
Checking NixOS...
testnode001: Linux testnode001 6.12.62 #1-NixOS SMP PREEMPT_DYNAMIC Fri Dec 12 17:37:22 UTC 2025 x86_64 GNU/Linux testnode001:
  ✓ nixos: ok (testnode001)
==========================================
Health checks: PASSED
Base image: rocky-10
Provisioning time: 00h:02m:18s
Total test time: 00h:03m:12s
******************************************
*** Rebuild testnode001 with alma-9 ***
Wait for rebuild to complete... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ - Action completed successfully!
Allow to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
Verify installed system:
AlmaLinux 9.7 (Moss Jungle Cat)
*** Provisioning NixOS 25.05 ***
- ************* SPAWNING NODES *************
- Node testnode001 already exists, skipping!
- ssh: !
- Converting to NixOS... 25.05
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- ssh: ......!
- Done!
DEBUG: + testnode001: NixOS
Allow rebuild to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
NixOS 25.05 (Warbler)
******************************************
==========================================
Running Fleet Health Checks
==========================================
Checking NixOS...
testnode001: Linux testnode001 6.12.62 #1-NixOS SMP PREEMPT_DYNAMIC Fri Dec 12 17:37:22 UTC 2025 x86_64 GNU/Linux testnode001:
  ✓ nixos: ok (testnode001)
==========================================
Health checks: PASSED
Base image: alma-9
Provisioning time: 00h:02m:15s
Total test time: 00h:03m:07s
******************************************
*** Rebuild testnode001 with alma-10 ***
Wait for rebuild to complete... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ - Action completed successfully!
Allow to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
Verify installed system:
AlmaLinux 10.1 (Heliotrope Lion)
*** Provisioning NixOS 25.05 ***
- ************* SPAWNING NODES *************
- Node testnode001 already exists, skipping!
- ssh: !
- Converting to NixOS... 25.05
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- ssh: .....!
- Done!
DEBUG: + testnode001: NixOS
Allow rebuild to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
NixOS 25.05 (Warbler)
******************************************
==========================================
Running Fleet Health Checks
==========================================
Checking NixOS...
testnode001: Linux testnode001 6.12.62 #1-NixOS SMP PREEMPT_DYNAMIC Fri Dec 12 17:37:22 UTC 2025 x86_64 GNU/Linux testnode001:
  ✓ nixos: ok (testnode001)
==========================================
Health checks: PASSED
Base image: alma-10
Provisioning time: 00h:02m:11s
Total test time: 00h:03m:06s
******************************************
*** Rebuild testnode001 with fedora-41 ***
Wait for rebuild to complete... zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
zzZjq: parse error: Invalid numeric literal at line 1, column 7
 - Timeout: Max tries reached
Allow to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
Verify installed system:
NixOS 25.05 (Warbler)
*** Provisioning NixOS 25.05 ***
- ************* SPAWNING NODES *************
- Node testnode001 already exists, skipping!
- ssh: !
- Converting to NixOS... 25.05
+++++++
- ssh: .....!
- Done!
DEBUG: + testnode001: NixOS
Allow rebuild to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
NixOS 25.05 (Warbler)
******************************************
==========================================
Running Fleet Health Checks
==========================================
Checking NixOS...
testnode001: Linux testnode001 6.12.62 #1-NixOS SMP PREEMPT_DYNAMIC Fri Dec 12 17:37:22 UTC 2025 x86_64 GNU/Linux testnode001:
  ✓ nixos: ok (testnode001)
==========================================
Health checks: PASSED
Base image: fedora-41
Provisioning time: 00h:00m:27s
Total test time: 00h:01m:31s
******************************************
*** Rebuild testnode001 with opensuse-15 ***
Wait for rebuild to complete... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ - Action completed successfully!
Allow to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
Verify installed system:
openSUSE Leap 15.6
*** Provisioning NixOS 25.05 ***
- ************* SPAWNING NODES *************
- Node testnode001 already exists, skipping!
- ssh: !
- Converting to NixOS... 25.05
+++++++++++++++
- ssh: ..........!
- Done!
DEBUG: + testnode001: NixOS
Allow rebuild to stabilise... zzZzzZzzZzzZzzZzzZzzZzzZzzZzzZ
NixOS 25.05 (Warbler)
******************************************
==========================================
Running Fleet Health Checks
==========================================
Checking NixOS...
testnode001: Linux testnode001 6.12.62 #1-NixOS SMP PREEMPT_DYNAMIC Fri Dec 12 17:37:22 UTC 2025 x86_64 GNU/Linux testnode001:
  ✓ nixos: ok (testnode001)
==========================================
Health checks: PASSED
Base image: opensuse-15
Provisioning time: 00h:02m:00s
Total test time: 00h:03m:01s
******************************************
            **              **            
            **              **            
******************************************
TOTAL TEST TIME: 00h:35m:39s
***************** DONE *******************
```