### PR TITLE
Fix bootFs empty

### DIFF
--- a/nixos-infect
+++ b/nixos-infect
@@ -268,25 +268,28 @@ prepareEnv() {
   # $esp and $grubdev are used in makeConf()
   if isEFI; then
     esp="$(findESP)"
-    if mount | grep -q /boot/efi; then
+    if mountpoint -q /boot/efi; then
       bootFs=/boot/efi
-    elif mount | grep -q /boot/EFI; then
+    elif mountpoint -q /boot/EFI; then
       bootFs=/boot/EFI
-    else
+    elif mountpoint -q /boot; then
       bootFs=/boot
+    else
+      bootFs=/boot/efi
     fi
   else
+    bootFs=/boot
     for grubdev in /dev/vda /dev/sda /dev/xvda /dev/nvme0n1 ; do [[ -e $grubdev ]] && break; done
   fi
 
-  # Retrieve root fs block device
-  #                   (get root mount)  (get partition or logical volume)
   rootfsdev=$(mount | grep "on / type" | awk '{print $1;}')
   rootfstype=$(df $rootfsdev --output=fstype | sed 1d)
 
-  # DigitalOcean doesn't seem to set USER while running user data
   export USER="root"
   export HOME="/root"
+  export bootFs
+  export esp
+
 
   # Nix installer tries to use sudo regardless of whether we're already uid 0
   #which sudo || { sudo() { eval "$@"; }; export -f sudo; }
@@ -367,6 +370,7 @@ infect() {
   for i in {1..10}; do
     useradd -c "Nix build user $i" -d /var/empty -g nixbld -G nixbld -M -N -r -s "$(which nologin)" "nixbld$i" || true
   done
+
   # TODO use addgroup and adduser as fallbacks
   #addgroup nixbld -g 30000 || true
   #for i in {1..10}; do adduser -DH -G nixbld nixbld$i || true; done
@@ -415,15 +419,24 @@ infect() {
   echo root/.nix-defexpr/channels >> /etc/NIXOS_LUSTRATE
   (cd / && ls etc/ssh/ssh_host_*_key* || true) >> /etc/NIXOS_LUSTRATE
 
-  rm -rf $bootFs.bak
-  isEFI && umount "$esp"
-
-  mv -v $bootFs $bootFs.bak || { cp -a $bootFs $bootFs.bak ; rm -rf $bootFs/* ; umount $bootFs ; }
-  if isEFI; then
-    mkdir -p $bootFs
-    mount "$esp" $bootFs
-    find $bootFs -depth ! -path $bootFs -exec rm -rf {} +
+  if [[ -z "$bootFs" ]]; then
+      echo "ERROR: bootFs is not defined. Aborting to prevent data loss."
+      exit 1
   fi
+
+  rm -rf "${bootFs}.bak"
+
+  if isEFI; then
+    umount "$bootFs" || true
+    mv -v "$bootFs" "${bootFs}.bak" || { cp -a "$bootFs" "${bootFs}.bak" ; rm -rf "$bootFs"/* ; }
+    mkdir -p "$bootFs"
+    mount "$esp" "$bootFs"
+    find "$bootFs" -depth ! -path "$bootFs" -exec rm -rf {} +
+  else
+    mv -v "$bootFs" "${bootFs}.bak" || { cp -a "$bootFs" "${bootFs}.bak" ; rm -rf "$bootFs"/* ; }
+    mkdir -p "$bootFs"
+  fi
+
   /nix/var/nix/profiles/system/bin/switch-to-configuration boot
 }
 
@@ -433,7 +446,7 @@ fi
 
 [ "$PROVIDER" = "lightsail" ] && newrootfslabel="nixos"
 if [[ "$PROVIDER" = "digitalocean" ]] || [[ "$PROVIDER" = "servarica" ]] || [[ "$PROVIDER" = "hetznercloud" ]] || [[ "$PROVIDER" = "webdock" ]] || [[ "$PROVIDER" = "layer7" ]] || [[ "$PROVIDER" = "hostinger" ]]; then
-	doNetConf=y # some providers require detailed network config to be generated
+    doNetConf=y # some providers require detailed network config to be generated
 fi
 
 checkEnv


### PR DESCRIPTION
# Fix a case where bootFs was empty

Log of the error i was having
```sh
+ [[ -L /etc/resolv.conf ]]
+ '[' -n '' ']'
+ touch /etc/NIXOS
+ echo etc/nixos
+ echo etc/resolv.conf
+ echo root/.nix-defexpr/channels
+ cd /
+ ls etc/ssh/ssh_host_ecdsa_key etc/ssh/ssh_host_ecdsa_key.pub etc/ssh/ssh_host_ed25519_key etc/ssh/ssh_host_ed25519_key.pub etc/ssh/ssh_host_rsa_key etc/ssh/ssh_host_rsa_key.pub
+ rm -rf .bak
+ isEFI
+ '[' -d /sys/firmware/efi ']'
+ mv -v .bak
mv: missing destination file operand after '.bak'
Try 'mv --help' for more information.
+ cp -a .bak
cp: missing destination file operand after '.bak'
Try 'cp --help' for more information.
```

This fix use now `mountpoint` instead of `mount`
mountpoint is introduce into `utils-linux` [v2.20](https://www.kernel.org/pub/linux/utils/util-linux/v2.20/v2.20-ChangeLog) in 2011

This is hopefully old enought to not be a issue.

If you think it can be a issue, i can introduce a check of it's existance and if not fallback on the old logic